### PR TITLE
Truncates used artifact id to workaround issue in docker 1.8.X

### DIFF
--- a/dockerfile/driver.go
+++ b/dockerfile/driver.go
@@ -1,18 +1,18 @@
 package dockerfile
 
 import (
-  "bytes"
+	"bytes"
 
-  "github.com/mitchellh/packer/builder/docker"
+	"github.com/mitchellh/packer/builder/docker"
 )
 
 // Driver is the interface that has to be implemented to communicate with
 // Docker. The Driver interface also allows the steps to be tested since
 // a mock driver can be shimmed in.
 type Driver interface {
-  docker.Driver
+	docker.Driver
 
-  // Build an image with the given Dockerfile and returns the ID for that image,
-  // along with a potential error.
-  BuildImage(dockerfile *bytes.Buffer) (string, error)
+	// Build an image with the given Dockerfile and returns the ID for that image,
+	// along with a potential error.
+	BuildImage(dockerfile *bytes.Buffer) (string, error)
 }

--- a/dockerfile/driver_docker.go
+++ b/dockerfile/driver_docker.go
@@ -1,46 +1,46 @@
 package dockerfile
 
 import (
-  "bytes"
-  "fmt"
-  "os/exec"
-  "regexp"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"regexp"
 
-  "github.com/mitchellh/packer/builder/docker"
+	"github.com/mitchellh/packer/builder/docker"
 )
 
 type DockerDriver struct {
-  *docker.DockerDriver
+	*docker.DockerDriver
 }
 
 func (d *DockerDriver) BuildImage(dockerfile *bytes.Buffer) (string, error) {
-  var stdout bytes.Buffer
-  var stderr bytes.Buffer
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 
-  cmd := exec.Command("docker", "build", "--force-rm=true", "--no-cache=true", "--quiet=true", "-")
-  cmd.Stdin = dockerfile
-  cmd.Stdout = &stdout
-  cmd.Stderr = &stderr
+	cmd := exec.Command("docker", "build", "--force-rm=true", "--no-cache=true", "--quiet=true", "-")
+	cmd.Stdin = dockerfile
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-  if err := cmd.Start(); err != nil {
-   return "", err
-  }
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
 
-  if err := cmd.Wait(); err != nil {
-    err = fmt.Errorf("Error building image: %s\nStderr: %s",
-      err, stderr.String())
-   return "", err
-  }
+	if err := cmd.Wait(); err != nil {
+		err = fmt.Errorf("Error building image: %s\nStderr: %s",
+			err, stderr.String())
+		return "", err
+	}
 
-  image_id_regexp := regexp.MustCompile("Successfully built ([a-f0-9]+)")
-  matches := image_id_regexp.FindStringSubmatch(stdout.String());
-  if matches == nil {
-    err := fmt.Errorf("Could not parse `docker build` output: %s",
-      stdout.String())
+	image_id_regexp := regexp.MustCompile("Successfully built ([a-f0-9]+)")
+	matches := image_id_regexp.FindStringSubmatch(stdout.String())
+	if matches == nil {
+		err := fmt.Errorf("Could not parse `docker build` output: %s",
+			stdout.String())
 
-    return "", err
-  }
-  id := matches[len(matches) - 1]
-  
-  return id, nil
+		return "", err
+	}
+	id := matches[len(matches)-1]
+
+	return id, nil
 }

--- a/dockerfile/driver_docker_test.go
+++ b/dockerfile/driver_docker_test.go
@@ -3,5 +3,5 @@ package dockerfile
 import "testing"
 
 func TestDockerDriver_impl(t *testing.T) {
-  var _ Driver = new(DockerDriver)
+	var _ Driver = new(DockerDriver)
 }

--- a/dockerfile/driver_mock.go
+++ b/dockerfile/driver_mock.go
@@ -1,22 +1,22 @@
 package dockerfile
 
 import (
-  "bytes"
+	"bytes"
 
-  "github.com/mitchellh/packer/builder/docker"
+	"github.com/mitchellh/packer/builder/docker"
 )
 
 // MockDriver is a driver implementation that can be used for tests.
 type MockDriver struct {
-  *docker.MockDriver
+	*docker.MockDriver
 
-  BuildImageCalled     bool
-  BuildImageDockerfile *bytes.Buffer
-  BuildImageErr        error
+	BuildImageCalled     bool
+	BuildImageDockerfile *bytes.Buffer
+	BuildImageErr        error
 }
 
 func (d *MockDriver) BuildImage(dockerfile *bytes.Buffer) (string, error) {
-  d.BuildImageCalled = true
-  d.BuildImageDockerfile = dockerfile
-  return "1234567890abcdef", d.BuildImageErr
+	d.BuildImageCalled = true
+	d.BuildImageDockerfile = dockerfile
+	return "1234567890abcdef", d.BuildImageErr
 }

--- a/dockerfile/driver_mock_test.go
+++ b/dockerfile/driver_mock_test.go
@@ -3,5 +3,5 @@ package dockerfile
 import "testing"
 
 func TestMockDriver_impl(t *testing.T) {
-  var _ Driver = new(MockDriver)
+	var _ Driver = new(MockDriver)
 }

--- a/dockerfile/post-processor.go
+++ b/dockerfile/post-processor.go
@@ -1,74 +1,74 @@
 package dockerfile
 
 import (
-  "fmt"
-  "log"
-  "bytes"
-  "bufio"
-  "text/template"
-  "encoding/json"
-  "reflect"
-  "strings"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"text/template"
 
-  "github.com/mitchellh/packer/builder/docker"
-  "github.com/mitchellh/packer/common"
-  "github.com/mitchellh/packer/helper/config"
-  "github.com/mitchellh/packer/packer"
-  "github.com/mitchellh/packer/post-processor/docker-import"
-  "github.com/mitchellh/packer/template/interpolate"
+	"github.com/mitchellh/packer/builder/docker"
+	"github.com/mitchellh/packer/common"
+	"github.com/mitchellh/packer/helper/config"
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/post-processor/docker-import"
+	"github.com/mitchellh/packer/template/interpolate"
 )
 
 const BuilderId = "packer.post-processor.docker-dockerfile"
 
 type Config struct {
-  common.PackerConfig `mapstructure:",squash"`
+	common.PackerConfig `mapstructure:",squash"`
 
-  From       string
-  Maintainer string            `mapstructure:"maintainer"`
-  Cmd        interface{}       `mapstructure:"cmd"`
-  Label      map[string]string `mapstructure:"label"`
-  Expose     []string          `mapstructure:"expose"`
-  Env        map[string]string `mapstructure:"env"`
-  Entrypoint interface{}       `mapstructure:"entrypoint"`
-  Volume     []string          `mapstructure:"volume"`
-  User       string            `mapstructure:"user"`
-  WorkDir    string            `mapstructure:"workdir"`
+	From       string
+	Maintainer string            `mapstructure:"maintainer"`
+	Cmd        interface{}       `mapstructure:"cmd"`
+	Label      map[string]string `mapstructure:"label"`
+	Expose     []string          `mapstructure:"expose"`
+	Env        map[string]string `mapstructure:"env"`
+	Entrypoint interface{}       `mapstructure:"entrypoint"`
+	Volume     []string          `mapstructure:"volume"`
+	User       string            `mapstructure:"user"`
+	WorkDir    string            `mapstructure:"workdir"`
 
-  ctx interpolate.Context
+	ctx interpolate.Context
 }
 
 type PostProcessor struct {
-  Driver Driver
+	Driver Driver
 
-  config Config
+	config Config
 }
 
 func (p *PostProcessor) Configure(raws ...interface{}) error {
-  err := config.Decode(&p.config, &config.DecodeOpts{
-    Interpolate: true,
-    InterpolateFilter: &interpolate.RenderFilter{
-      Exclude: []string{},
-    },
-  }, raws...)
-  if err != nil {
-    return err
-  }
+	err := config.Decode(&p.config, &config.DecodeOpts{
+		Interpolate: true,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{},
+		},
+	}, raws...)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-  if artifact.BuilderId() != dockerimport.BuilderId {
-    err := fmt.Errorf(
-      "Unknown artifact type: %s\nCan only build with Dockerfile from Docker builder artifacts.",
-      artifact.BuilderId())
-    return nil, false, err
-  }
+	if artifact.BuilderId() != dockerimport.BuilderId {
+		err := fmt.Errorf(
+			"Unknown artifact type: %s\nCan only build with Dockerfile from Docker builder artifacts.",
+			artifact.BuilderId())
+		return nil, false, err
+	}
 
-  p.config.From = artifact.Id()
+	p.config.From = artifact.Id()
 
-  template_str := `FROM {{ .From }}
+	template_str := `FROM {{ .From }}
 {{ if .Maintainer }}MAINTAINER {{ .Maintainer }}
 {{ end }}{{ if .Cmd }}CMD {{ process .Cmd }}
 {{ end }}{{ if .Label }}{{ range $k, $v := .Label }}LABEL "{{ $k }}"="{{ $v }}"
@@ -79,70 +79,70 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 {{ end }}{{ if .User }}USER {{ .User }}
 {{ end }}{{ if .WorkDir }}WORKDIR {{ .WorkDir }}{{ end }}`
 
-  dockerfile := new(bytes.Buffer)
-  template_writer := bufio.NewWriter(dockerfile)
+	dockerfile := new(bytes.Buffer)
+	template_writer := bufio.NewWriter(dockerfile)
 
-  tmpl, err := template.New("Dockerfile").Funcs(template.FuncMap{
-      "process": p.processVar,
-      "join":    strings.Join,
-    }).Parse(template_str)
-  if err != nil {
-    return nil, false, err
-  }
-  err = tmpl.Execute(template_writer, p.config)
-  if err != nil {
-    return nil, false, err
-  }
-  template_writer.Flush()
-  log.Printf("Dockerfile:\n%s", dockerfile.String())
+	tmpl, err := template.New("Dockerfile").Funcs(template.FuncMap{
+		"process": p.processVar,
+		"join":    strings.Join,
+	}).Parse(template_str)
+	if err != nil {
+		return nil, false, err
+	}
+	err = tmpl.Execute(template_writer, p.config)
+	if err != nil {
+		return nil, false, err
+	}
+	template_writer.Flush()
+	log.Printf("Dockerfile:\n%s", dockerfile.String())
 
-  driver := p.Driver
-  if driver == nil {
-    // If no driver is set, then we use the real driver
-    driver = &DockerDriver{&docker.DockerDriver{Ctx: &p.config.ctx, Ui: ui}}
-  }
-  
-  ui.Message("Base image ID: " + artifact.Id())
-  id, err := driver.BuildImage(dockerfile)
-  if err != nil {
-    return nil, false, err
-  }
+	driver := p.Driver
+	if driver == nil {
+		// If no driver is set, then we use the real driver
+		driver = &DockerDriver{&docker.DockerDriver{Ctx: &p.config.ctx, Ui: ui}}
+	}
 
-  ui.Message("Image ID: " + id)
+	ui.Message("Base image ID: " + artifact.Id())
+	id, err := driver.BuildImage(dockerfile)
+	if err != nil {
+		return nil, false, err
+	}
 
-  // Build the artifact
-  artifact = &docker.ImportArtifact{
-    BuilderIdValue: dockerimport.BuilderId,
-    Driver:         driver,
-    IdValue:        id,
-  }
+	ui.Message("Image ID: " + id)
 
-  return artifact, true, nil
+	// Build the artifact
+	artifact = &docker.ImportArtifact{
+		BuilderIdValue: dockerimport.BuilderId,
+		Driver:         driver,
+		IdValue:        id,
+	}
+
+	return artifact, true, nil
 }
 
 // Process a variable of unknown type.
 func (p *PostProcessor) processVar(variable interface{}) (string, error) {
-  switch t := variable.(type) {
-  case []string:
-    array := make([]string, 0, len(t))
-    for _, item := range t {
-      array = append(array, item)
-    }
-    res, _ := json.Marshal(array)
-    return string(res), nil
-  case []interface{}:
-    array := make([]string, 0, len(t))
-    for _, item := range t {
-      array = append(array, item.(string))
-    }
-    res, _ := json.Marshal(array)
-    return string(res), nil
-  case string:
-    return t, nil
-  case nil:
-    return "", nil
-  }
+	switch t := variable.(type) {
+	case []string:
+		array := make([]string, 0, len(t))
+		for _, item := range t {
+			array = append(array, item)
+		}
+		res, _ := json.Marshal(array)
+		return string(res), nil
+	case []interface{}:
+		array := make([]string, 0, len(t))
+		for _, item := range t {
+			array = append(array, item.(string))
+		}
+		res, _ := json.Marshal(array)
+		return string(res), nil
+	case string:
+		return t, nil
+	case nil:
+		return "", nil
+	}
 
-  err := fmt.Errorf("Unsupported variable type: %s", reflect.TypeOf(variable))
-  return "", err
+	err := fmt.Errorf("Unsupported variable type: %s", reflect.TypeOf(variable))
+	return "", err
 }

--- a/dockerfile/post-processor_test.go
+++ b/dockerfile/post-processor_test.go
@@ -1,75 +1,75 @@
 package dockerfile
 
 import (
-  "bytes"
-  "testing"
+	"bytes"
+	"testing"
 
-  "github.com/mitchellh/packer/packer"
-  "github.com/mitchellh/packer/post-processor/docker-import"
+	"github.com/mitchellh/packer/packer"
+	"github.com/mitchellh/packer/post-processor/docker-import"
 )
 
 func testConfig() map[string]interface{} {
-  return map[string]interface{}{
-    "maintainer": "foo",
-    "cmd":        []interface{}{ "/foo/bar" },
-    "label":      map[string]string{ "foo": "bar" },
-    "expose":     []string{ "1234" },
-    "env":        map[string]string{ "foo": "bar" },
-    "entrypoint": []interface{}{ "/foo/bar" },
-    "volume":     []string{ "/foo/bar" },
-    "user":       "foo",
-    "workdir":    "/foo/bar",
-  }
+	return map[string]interface{}{
+		"maintainer": "foo",
+		"cmd":        []interface{}{"/foo/bar"},
+		"label":      map[string]string{"foo": "bar"},
+		"expose":     []string{"1234"},
+		"env":        map[string]string{"foo": "bar"},
+		"entrypoint": []interface{}{"/foo/bar"},
+		"volume":     []string{"/foo/bar"},
+		"user":       "foo",
+		"workdir":    "/foo/bar",
+	}
 }
 
 func testPP(t *testing.T) *PostProcessor {
-  var p PostProcessor
-  if err := p.Configure(testConfig()); err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	var p PostProcessor
+	if err := p.Configure(testConfig()); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  return &p
+	return &p
 }
 
 func testUi() *packer.BasicUi {
-  return &packer.BasicUi{
-    Reader: new(bytes.Buffer),
-    Writer: new(bytes.Buffer),
-  }
+	return &packer.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
 }
 
 func TestPostProcessor_ImplementsPostProcessor(t *testing.T) {
-  var _ packer.PostProcessor = new(PostProcessor)
+	var _ packer.PostProcessor = new(PostProcessor)
 }
 
 func TestPostProcessor_PostProcess(t *testing.T) {
-  driver := &MockDriver{}
-  p := &PostProcessor{Driver: driver}
-  if err := p.Configure(testConfig()); err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	driver := &MockDriver{}
+	p := &PostProcessor{Driver: driver}
+	if err := p.Configure(testConfig()); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  artifact := &packer.MockArtifact{
-    BuilderIdValue: dockerimport.BuilderId,
-    IdValue:        "1234567890abcdef",
-  }
+	artifact := &packer.MockArtifact{
+		BuilderIdValue: dockerimport.BuilderId,
+		IdValue:        "1234567890abcdef",
+	}
 
-  result, keep, err := p.PostProcess(testUi(), artifact)
-  if _, ok := result.(packer.Artifact); !ok {
-    t.Fatal("should be instance of Artifact")
-  }
-  if !keep {
-    t.Fatal("should keep")
-  }
-  if err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	result, keep, err := p.PostProcess(testUi(), artifact)
+	if _, ok := result.(packer.Artifact); !ok {
+		t.Fatal("should be instance of Artifact")
+	}
+	if !keep {
+		t.Fatal("should keep")
+	}
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  if !driver.BuildImageCalled {
-    t.Fatal("should call BuildImage")
-  }
+	if !driver.BuildImageCalled {
+		t.Fatal("should call BuildImage")
+	}
 
-  dockerfile := `FROM 1234567890abcdef
+	dockerfile := `FROM 1234567890abcdef
 MAINTAINER foo
 CMD ["/foo/bar"]
 LABEL "foo"="bar"
@@ -80,44 +80,44 @@ VOLUME ["/foo/bar"]
 USER foo
 WORKDIR /foo/bar`
 
-  if driver.BuildImageDockerfile.String() != dockerfile {
-    t.Fatalf("should render Dockerfile correctly: %s", driver.BuildImageDockerfile.String())
-  }
+	if driver.BuildImageDockerfile.String() != dockerfile {
+		t.Fatalf("should render Dockerfile correctly: %s", driver.BuildImageDockerfile.String())
+	}
 }
 
 func TestPostProcessor_processVar(t *testing.T) {
-  driver := &MockDriver{}
-  p := &PostProcessor{Driver: driver}
-  if err := p.Configure(testConfig()); err != nil {
-    t.Fatalf("err: %s", err)
-  }
+	driver := &MockDriver{}
+	p := &PostProcessor{Driver: driver}
+	if err := p.Configure(testConfig()); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-  res, err := p.processVar("foo");
-  if err != nil {
-    t.Fatalf("failed to process variable: %s", err)
-  }
-  if res != "foo" {
-    t.Fatalf("should be foo: %s", res)
-  }
+	res, err := p.processVar("foo")
+	if err != nil {
+		t.Fatalf("failed to process variable: %s", err)
+	}
+	if res != "foo" {
+		t.Fatalf("should be foo: %s", res)
+	}
 
-  res, err = p.processVar([]string{ "foo", "bar" });
-  if err != nil {
-    t.Fatalf("failed to process variable: %s", err)
-  }
-  if res != `["foo","bar"]` {
-    t.Fatalf(`should be ["foo","bar"]: %s`, res)
-  }
+	res, err = p.processVar([]string{"foo", "bar"})
+	if err != nil {
+		t.Fatalf("failed to process variable: %s", err)
+	}
+	if res != `["foo","bar"]` {
+		t.Fatalf(`should be ["foo","bar"]: %s`, res)
+	}
 
-  res, err = p.processVar([]interface{}{ "foo", "bar" });
-  if err != nil {
-    t.Fatalf("failed to process variable: %s", err)
-  }
-  if res != `["foo","bar"]` {
-    t.Fatalf(`should be ["foo","bar"]: %s`, res)
-  }
+	res, err = p.processVar([]interface{}{"foo", "bar"})
+	if err != nil {
+		t.Fatalf("failed to process variable: %s", err)
+	}
+	if res != `["foo","bar"]` {
+		t.Fatalf(`should be ["foo","bar"]: %s`, res)
+	}
 
-  _, err = p.processVar(nil);
-  if err != nil {
-    t.Fatalf("failed to process variable: %s", err)
-  }
+	_, err = p.processVar(nil)
+	if err != nil {
+		t.Fatalf("failed to process variable: %s", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-  "github.com/mitchellh/packer/packer/plugin"
+	"github.com/mitchellh/packer/packer/plugin"
 
-  "github.com/jgkim/packer-post-processor-docker-dockerfile/dockerfile"
+	"github.com/jgkim/packer-post-processor-docker-dockerfile/dockerfile"
 )
 
 func main() {
-  server, err := plugin.Server()
-  if err != nil {
-    panic(err)
-  }
-  server.RegisterPostProcessor(new(dockerfile.PostProcessor))
-  server.Serve()
+	server, err := plugin.Server()
+	if err != nil {
+		panic(err)
+	}
+	server.RegisterPostProcessor(new(dockerfile.PostProcessor))
+	server.Serve()
 }


### PR DESCRIPTION
Truncates artifact id to workaround docker/docker#16218.

It also formats all the code [according to go fmt standards](https://blog.golang.org/go-fmt-your-code).
