### PR TITLE
Match docker 1.11 generated image IDs

### DIFF
--- a/dockerfile/driver_docker.go
+++ b/dockerfile/driver_docker.go
@@ -32,7 +32,7 @@ func (d *DockerDriver) BuildImage(dockerfile *bytes.Buffer) (string, error) {
    return "", err
   }
 
-  image_id_regexp := regexp.MustCompile("Successfully built ([a-f0-9]+)")
+  image_id_regexp := regexp.MustCompile("((?:sha256:)?[a-f0-9]+)")
   matches := image_id_regexp.FindStringSubmatch(stdout.String());
   if matches == nil {
     err := fmt.Errorf("Could not parse `docker build` output: %s",


### PR DESCRIPTION
I'm getting this error when trying to use the post processor:
- Post-processor failed: Could not parse `docker build` output: sha256:7d57f6744acb75e0a5ad3939844d5970604b60940d016bb4a540a44eeafea8a7

Looks like the "docker build" command has changed the message it shows after building the image. So I've tried with a new regexp. I used (?:sha256:)? to match image ids composed only of hexadecimal digits. It is only a safety measure... I haven't tested it with previous versions of docker.

This change works for me with docker 1.11.0:

==> docker: Running post-processor: docker-dockerfile
    docker (docker-dockerfile): Base image ID: sha256:c3949b417727055a20c1ea7e143172b30f467ca80e051cebf9781bbf711c2c03
    docker (docker-dockerfile): Image ID: sha256:7f539c23418e440ad64a78d564f8073f5a563843beaf1a36435fde27afca032a
